### PR TITLE
Remove Blank view if glance mode unsupported

### DIFF
--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -108,11 +108,11 @@ class HassControlApp extends App.AppBase {
     }
 
     var deviceSettings = System.getDeviceSettings();
-    var view = null;
-    var delegate = null;
-
+    
     if (deviceSettings has :isGlanceModeEnabled) {
       if (deviceSettings.isGlanceModeEnabled) {
+      	var view = null;
+	    var delegate = null;
         var initialView = getStartView();
 
         if (initialView.equals(HassControlApp.ENTITIES_VIEW)) {
@@ -125,18 +125,20 @@ class HassControlApp extends App.AppBase {
           view = sceneView[0];
           delegate = sceneView[1];
         }
+        
+        if (view == null || delegate == null) {
+	      view = new BaseView();
+	      delegate = new BaseDelegate();
+	    }
+	  
+	    return [
+	      view,
+	      delegate
+	    ];
       }
     }
-
-    if (view == null || delegate == null) {
-      view = new BaseView();
-      delegate = new BaseDelegate();
-    }
-
-
-    return [
-      view,
-      delegate
-    ];
+    
+    launchInitialView();
+    return viewController.getSceneView();
   }
 }

--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -112,7 +112,7 @@ class HassControlApp extends App.AppBase {
     if (deviceSettings has :isGlanceModeEnabled) {
       if (deviceSettings.isGlanceModeEnabled) {
       	var view = null;
-	    var delegate = null;
+	      var delegate = null;
         var initialView = getStartView();
 
         if (initialView.equals(HassControlApp.ENTITIES_VIEW)) {
@@ -127,14 +127,14 @@ class HassControlApp extends App.AppBase {
         }
         
         if (view == null || delegate == null) {
-	      view = new BaseView();
-	      delegate = new BaseDelegate();
-	    }
+          view = new BaseView();
+          delegate = new BaseDelegate();
+        }
 	  
-	    return [
-	      view,
-	      delegate
-	    ];
+        return [
+          view,
+          delegate
+        ];
       }
     }
     

--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -138,7 +138,6 @@ class HassControlApp extends App.AppBase {
       }
     }
     
-    launchInitialView();
-    return viewController.getSceneView();
+    return launchInitialView();
   }
 }

--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -37,6 +37,19 @@ class HassControlApp extends App.AppBase {
     return viewController.pushSceneView();
   }
 
+    function getInitialView() {
+    var initialView = getStartView();
+
+    if (initialView.equals(HassControlApp.ENTITIES_VIEW)) {
+      return viewController.getEntityView();
+    }
+    if (initialView.equals(HassControlApp.SCENES_VIEW)) {
+      return viewController.getSceneView();
+    }
+
+    return viewController.getSceneView();
+  }
+
   function onSettingsChanged() {
     Hass.loadScenesFromSettings();
     Hass.client.onSettingsChanged();
@@ -138,6 +151,6 @@ class HassControlApp extends App.AppBase {
       }
     }
     
-    return launchInitialView();
+    return getInitialView();
   }
 }

--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -37,19 +37,6 @@ class HassControlApp extends App.AppBase {
     return viewController.pushSceneView();
   }
 
-    function getInitialView() {
-    var initialView = getStartView();
-
-    if (initialView.equals(HassControlApp.ENTITIES_VIEW)) {
-      return viewController.getEntityView();
-    }
-    if (initialView.equals(HassControlApp.SCENES_VIEW)) {
-      return viewController.getSceneView();
-    }
-
-    return viewController.getSceneView();
-  }
-
   function onSettingsChanged() {
     Hass.loadScenesFromSettings();
     Hass.client.onSettingsChanged();
@@ -121,11 +108,11 @@ class HassControlApp extends App.AppBase {
     }
 
     var deviceSettings = System.getDeviceSettings();
+    var view = null;
+    var delegate = null;
     
     if (deviceSettings has :isGlanceModeEnabled) {
       if (deviceSettings.isGlanceModeEnabled) {
-      	var view = null;
-	      var delegate = null;
         var initialView = getStartView();
 
         if (initialView.equals(HassControlApp.ENTITIES_VIEW)) {
@@ -137,20 +124,18 @@ class HassControlApp extends App.AppBase {
           var sceneView = viewController.getSceneView();
           view = sceneView[0];
           delegate = sceneView[1];
-        }
-        
-        if (view == null || delegate == null) {
-          view = new BaseView();
-          delegate = new BaseDelegate();
-        }
-	  
-        return [
-          view,
-          delegate
-        ];
+        }      
       }
     }
     
-    return getInitialView();
+    if (view == null || delegate == null) {
+      view = new BaseView();
+      delegate = new BaseDelegate();
+    }
+
+    return return [
+      view,
+      delegate
+    ];
   }
 }

--- a/widget/source/BaseView.mc
+++ b/widget/source/BaseView.mc
@@ -2,29 +2,18 @@ using Toybox.WatchUi as Ui;
 using Toybox.Application as App;
 
 class BaseView extends Ui.View {
-    hidden var _firstLoad;
-
-    function initialize() {
-        View.initialize();
-        _firstLoad = true;
-    }
-
-    function onShow() {
-    }
 
     // Load your resources here
-    function onLayout(dc) {
-        var scene = new WatchUi.Text({
-            :text => "HassControl",
+    function onLayout(dc) {        
+        var text = new WatchUi.Text({
+            :text => "Hass Control\nTouch to continue.",
             :color => Graphics.COLOR_WHITE,
-            :font => Graphics.FONT_LARGE,
+            :font => Graphics.FONT_SMALL,
             :locX => WatchUi.LAYOUT_HALIGN_CENTER,
             :locY => WatchUi.LAYOUT_VALIGN_CENTER
         });
-        setLayout([scene]);
-    }
-
-    function onUpdate(dc) {
-        View.onUpdate(dc);
+        setLayout([text]);
+        
+        App.getApp().launchInitialView();
     }
 }


### PR DESCRIPTION
Changes
---
Removed extra "HassControl" view on devices that don't support glance mode (such as the vivoactive 3)

Reason for Changes
---
This change makes the widget easier to use on devices without glance mode, due to not having to tap the screen an extra time.