### PR TITLE
Bugfix/remove auto group prefix

### DIFF
--- a/widget/manifest.xml
+++ b/widget/manifest.xml
@@ -39,6 +39,7 @@
             <iq:product id="vivoactive3mlte"/>
             <iq:product id="vivoactive4"/>
             <iq:product id="vivoactive4s"/>
+            <iq:product id="descentg1"/>
         </iq:products>
         <iq:permissions>
             <iq:uses-permission id="Communications"/>

--- a/widget/manifest.xml
+++ b/widget/manifest.xml
@@ -39,7 +39,6 @@
             <iq:product id="vivoactive3mlte"/>
             <iq:product id="vivoactive4"/>
             <iq:product id="vivoactive4s"/>
-            <iq:product id="descentg1"/>
         </iq:products>
         <iq:permissions>
             <iq:uses-permission id="Communications"/>

--- a/widget/source/hass/Hass.mc
+++ b/widget/source/hass/Hass.mc
@@ -19,9 +19,9 @@ module Hass {
   function getGroup() {
     var group = App.Properties.getValue("group");
 
-    if (group.find("group.") == null) {
-      group = "group." + group;
-    }
+    // if (group.find("group.") == null) {
+    //   group = "group." + group;
+    // }
 
     return group;
   }
@@ -254,7 +254,7 @@ module Hass {
   function importEntities() {
     var group = getGroup();
 
-    if (group == null || group.find("group.") == null) {
+    if (group == null) {
       App.getApp().viewController.showError(group + "\nis not a valid\ngroup");
       return;
     }


### PR DESCRIPTION
app automatically adds group. prefix to a neme of HA group used for sync.
But groups in HA I just created does not start with group. It's called switch.garmin.
So I had to remove this auto-prefixing.