### PR TITLE
Add Union Entity/Scenes view and extend Start View Selection

### DIFF
--- a/widget/source/Menu/MenuController.mc
+++ b/widget/source/Menu/MenuController.mc
@@ -15,6 +15,7 @@ class MenuController {
 
         MENU_SELECT_START_VIEW_ENTITIES,
         MENU_SELECT_START_VIEW_SCENES,
+        MENU_SELECT_START_VIEW_ENTITIES_SCENES,
 
         MENU_BACK
     }
@@ -96,6 +97,7 @@ class MenuController {
         var currentStartView = App.getApp().getStartView();
         var entitiesSubtitle = "";
         var scenesSubtitle = "";
+        var entitiesScenesSubtitle = "";
 
         if (currentStartView == HassControlApp.ENTITIES_VIEW) {
             entitiesSubtitle = "selected";
@@ -103,6 +105,10 @@ class MenuController {
 
         if (currentStartView == HassControlApp.SCENES_VIEW) {
             scenesSubtitle = "selected";
+        }
+
+        if (currentStartView == HassControlApp.ENTITIES_SCENES_VIEW) {
+            entitiesScenesSubtitle = "selected";
         }
 
         menu.addItem(new Ui.MenuItem(
@@ -119,7 +125,14 @@ class MenuController {
             {}
         ));
 
-        menu.addItem(new Ui.MenuItem(
+         menu.addItem(new Ui.MenuItem(
+            "Entities and Scenes",
+            entitiesScenesSubtitle,
+            MenuController.MENU_SELECT_START_VIEW_ENTITIES_SCENES,
+            {}
+        ));
+
+         menu.addItem(new Ui.MenuItem(
             "Back",
             "",
             MenuController.MENU_BACK,

--- a/widget/source/Menu/MenuDelegate.mc
+++ b/widget/source/Menu/MenuDelegate.mc
@@ -65,6 +65,15 @@ class MenuDelegate extends Ui.Menu2InputDelegate {
             App.getApp().menu.showSettingsMenu();
             return true;
         }
+        if (itemId == MenuController.MENU_SELECT_START_VIEW_ENTITIES_SCENES) {
+            App.getApp().setStartView(HassControlApp.ENTITIES_SCENES_VIEW);
+
+            // TOTO: This is a dirty hack to get the parent menu to re render
+            Ui.popView(Ui.SLIDE_IMMEDIATE);
+            Ui.popView(Ui.SLIDE_IMMEDIATE);
+            App.getApp().menu.showSettingsMenu();
+            return true;
+        }
 
         /*
          * GLOBAL MENU OPTIONS

--- a/widget/source/ViewController.mc
+++ b/widget/source/ViewController.mc
@@ -37,6 +37,28 @@ class ViewController {
     return _loaderActive != null && !_errorView.isActive() && !_loginView.isActive();
   }
 
+  function getEntitySceneView() 
+  {
+    var controller = new EntityListController(
+      [
+        Hass.TYPE_SCENE,
+        Hass.TYPE_LIGHT,
+        Hass.TYPE_SWITCH,
+        Hass.TYPE_AUTOMATION,
+        Hass.TYPE_SCRIPT,
+        Hass.TYPE_LOCK,
+        Hass.TYPE_COVER,
+        Hass.TYPE_BINARY_SENSOR,
+        Hass.TYPE_INPUT_BOOLEAN
+      ]
+    );
+
+    return [
+      new EntityListView(controller),
+      new EntityListDelegate(controller)
+    ];
+  }
+
   function getSceneView() {
     var controller = new EntityListController(
       [Hass.TYPE_SCENE]
@@ -90,6 +112,16 @@ class ViewController {
 
   function pushEntityView() {
     var view = getEntityView();
+
+    Ui.pushView(
+      view[0],
+      view[1],
+      Ui.SLIDE_IMMEDIATE
+    );
+  }
+
+  function pushEntityScenesView() {
+    var view = getEntitySceneView();
 
     Ui.pushView(
       view[0],


### PR DESCRIPTION
For smaller home assistant instances, it can be useful to have no separate Entities/Scenes views. Thus I added a third view option displaying scenes and entities on one 'screen'.